### PR TITLE
Fixed minor bug in writeObj function

### DIFF
--- a/src/boundingmesh/Mesh.cpp
+++ b/src/boundingmesh/Mesh.cpp
@@ -611,7 +611,7 @@ namespace boundingmesh
 				<< " " << vertices_[i].position_[1]
 				<< " " << vertices_[i].position_[2] << std::endl;
 		}
-		file << "# " << triangles_.size() << " triangles total";	
+		file << "# " << triangles_.size() << " triangles total" << std::endl;	
 		for(unsigned int i = 0; i <triangles_.size(); ++i)
 		{
 			//Obj indices count from 1


### PR DESCRIPTION
The first triangle was originally printed on the same line as the comment. This commit adds a new line before printing the triangles.
