### PR TITLE
Using assimp to load objects

### DIFF
--- a/src/boundingmesh-bin/boundingmesh-cli.cpp
+++ b/src/boundingmesh-bin/boundingmesh-cli.cpp
@@ -221,27 +221,11 @@ int main(int argc, char** argv) {
   }
 
   boundingmesh::Mesh mesh;
-  boundingmesh::FileFormat file_format_in = boundingmesh::Invalid;
   boundingmesh::FileFormat file_format_out = boundingmesh::Invalid;
 
-  file_format_in = boundingmesh::getFileFormat(filename_in);
   file_format_out = boundingmesh::getFileFormat(filename_out);
 
-  if (file_format_in == boundingmesh::Off)
-    mesh.loadOff(filename_in);
-  else if (file_format_in == boundingmesh::Obj)
-    mesh.loadObj(filename_in);
-  else if (file_format_in == boundingmesh::Wrl) {
-    if (options[WHICH_FACESET])
-      mesh.loadWrl(filename_in, atoi(options[WHICH_FACESET].arg));
-    else
-      mesh.loadWrl(filename_in);
-  } else if (file_format_in == boundingmesh::Stl)
-    mesh.loadStl(filename_in);
-  else {
-    std::cout << "Couldn't load " << filename_in << std::endl;
-    return 1;
-  }
+  mesh.loadFile(filename_in);
 
   boundingmesh::Decimator decimator(direction);
   if (options[TARGET_VERTICES]) {

--- a/src/boundingmesh-gui/gui.cpp
+++ b/src/boundingmesh-gui/gui.cpp
@@ -130,37 +130,22 @@ void MainWindow::loadView() {
 
 bool MainWindow::openFile(const std::string &filename_in) {
   mesh.reset(new boundingmesh::Mesh);
-  boundingmesh::FileFormat file_format_in = boundingmesh::Invalid;
-  file_format_in = boundingmesh::getFileFormat(filename_in);
-  if (file_format_in == boundingmesh::Off)
-    mesh->loadOff(filename_in);
-  else if (file_format_in == boundingmesh::Obj)
-    mesh->loadObj(filename_in);
-  else if (file_format_in == boundingmesh::Wrl)
-    mesh->loadWrl(filename_in);
-  else if (file_format_in == boundingmesh::Stl)
-    mesh->loadStl(filename_in);
-  else {
-    QMessageBox::warning(this, "Bad File Format", "File type cannot be read.",
-                         QMessageBox::Ok);
-    return false;
-  }
+  mesh->loadFile(filename_in);
   loadView();
   return true;
 }
 
 void MainWindow::clickOpen() {
-  std::string filename_in =
-      QFileDialog::getOpenFileName(this, "Open 3D Mesh", QDir::currentPath(),
-                                   "*.wrl *.obj *.off *.stl")
-          .toStdString();
+  std::string filename_in = QFileDialog::getOpenFileName(
+                                this, "Open 3D Mesh", QDir::currentPath(), "*")
+                                .toStdString();
   if (filename_in == "") return;
   openFile(filename_in);
 }
 
 void MainWindow::clickOpenExample(const std::string &file_name) {
   mesh.reset(new boundingmesh::Mesh);
-  mesh->loadOff(file_name);
+  mesh->loadFile(file_name);
   if (mesh->nVertices() == 0) {
     QMessageBox::warning(this, "Bad Example File",
                          QString("File %1 cannot be read.")
@@ -413,9 +398,7 @@ void MainWindow::dropEvent(QDropEvent *event) {
 #include <QtOpenGL/QGLWidget>
 
 MainWindow::MainWindow(QWidget *parent, QApplication *app)
-    : app(app),
-      viewer(NULL),
-      using_error_restriction_(true) {
+    : app(app), viewer(NULL), using_error_restriction_(true) {
   SoQt::init(this);
   SoDB::init();
 

--- a/src/boundingmesh/CMakeLists.txt
+++ b/src/boundingmesh/CMakeLists.txt
@@ -4,8 +4,13 @@ find_package(Eigen 3 REQUIRED)
 find_package(Coin)
 find_package(CGAL)
 find_package(GMP)
+find_package(assimp)
 
 set(BOUNDINGMESH_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+
+set(ASSIMP_LIBRARY "assimp")
+add_library(${ASSIMP_LIBRARY} SHARED IMPORTED)
+set_target_properties(${ASSIMP_LIBRARY} PROPERTIES IMPORTED_LOCATION "${ASSIMP_LIBRARY_DIRS}/libassimp.so")
 
 if(COIN_FOUND)
 	add_definitions(-DCOIN_AVAILABLE -DCOIN_NOT_DLL)
@@ -89,6 +94,8 @@ set(
 
 set(BOUNDINGMESH_LIBRARIES boundingmesh boundingmeshdecomposition)
 
+target_link_libraries(boundingmesh ${ASSIMP_LIBRARY})
+
 if(COIN_FOUND)
 	set(BOUNDINGMESH_LIBRARIES ${BOUNDINGMESH_LIBRARIES} ${COIN_LIBRARIES})
 endif(COIN_FOUND)
@@ -124,6 +131,7 @@ install(
 	FILES ${BOUNDINGMESH_HDRS}
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
 install(
 	TARGETS boundingmesh
 	EXPORT boundingmesh-export
@@ -153,6 +161,7 @@ export(
 	TARGETS boundingmesh
 	FILE ${CMAKE_CURRENT_BINARY_DIR}/boundingmesh-export.cmake
 )
+
 install(
 	EXPORT boundingmesh-export
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/boundingmesh/FileUtils.cpp
+++ b/src/boundingmesh/FileUtils.cpp
@@ -63,19 +63,10 @@ std::shared_ptr<boundingmesh::Mesh> loadMesh(std::string filename,
   std::shared_ptr<boundingmesh::Mesh> mesh =
       std::make_shared<boundingmesh::Mesh>();
 
-  file_format = getFileFormat(filename);
-  if (file_format == Off)
-    mesh->loadOff(filename);
-  else if (file_format == Obj)
-    mesh->loadObj(filename);
-  else if (file_format == Wrl)
-    mesh->loadWrl(filename, -1, debugOutput);
-  else if (file_format == Stl)
-    mesh->loadStl(filename);
-  else {
-    std::cout << "Couldn't load mesh from " << filename << std::endl;
+  bool loadSuccess = mesh->loadFile(filename);
+  if (!loadSuccess) {
     return NULL;
   }
   return mesh;
 }
-}
+}  // namespace boundingmesh

--- a/src/boundingmesh/Mesh.h
+++ b/src/boundingmesh/Mesh.h
@@ -101,11 +101,7 @@ class Mesh {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // Loading/Saving files
-  void loadOff(const std::string& filename);
-  void loadObj(const std::string& filename);
-  void loadWrl(const std::string& filename, int faceset = -1,
-               bool debugOutput = true);
-  void loadStl(const std::string& filename);
+  bool loadFile(const std::string& filename);
   void writeOff(const std::string& filename);
   void writeObj(const std::string& filename);
   void writeWrl(const std::string& filename, bool colored = false);

--- a/src/boundingmesh/SegmenterSimple.cpp
+++ b/src/boundingmesh/SegmenterSimple.cpp
@@ -173,4 +173,4 @@ Real SegmenterSimple::evaluateSubset(const VoxelSubset& subset) {
   // Real val = subset.evaluate();
   return 1;
 }
-}
+}  // namespace boundingmesh


### PR DESCRIPTION
Hi, 

Thanks for this amazing project, which is working really great. 

However, there are a lot of file types not supported and even for file types supported, some are not loading as expected. I think that you could benefit from using a library like [assimp](https://github.com/assimp/assimp) to load your objects. 
It simplifies the code and allows a better loading. 

I did it with a simple car : 

*With your loading*
![loading-before](https://user-images.githubusercontent.com/26838971/67748141-83e67600-fa2a-11e9-8c84-6b41f91b3df3.png)

*With assimp loading*
![loading-after](https://user-images.githubusercontent.com/26838971/67748166-906ace80-fa2a-11e9-80b8-bf94a06b6907.png)

*Some artefacts remain on the car dur to the fact that the obj file defines several parts and your object is a single array*

It comes from the fact that some *.obj* files can have 4 vertices coordinates and you are only reading 3 for example, and the result is that you are missing one triangle over two. 

It is also possible to load files like *.glb*, this one is working great for example [avocado](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Avocado). However some are not working ([buggy](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Buggy)) because of asserts in the *addTriangle* method. 

Hope this helps !
Thanks again for this amazing project. 
