### PR TITLE
bugfix/closehole

### DIFF
--- a/src/boundingmesh/Mesh.cpp
+++ b/src/boundingmesh/Mesh.cpp
@@ -1037,6 +1037,9 @@ void Mesh::closeHoles() {
                 quit = true;
               }
               break;
+            } 
+            else if (j == v.edges_.size()-1){
+              quit = true;
             }
           }
           if (currentHoleEdges.size() > 10000) {


### PR DESCRIPTION
When I tested using our own mesh, `bounding-convex-decomposition` was not working well.
and there is an infinite loop on `closeHoles` function in some conditions.
(without this code, some mesh get stuck!)

Could you check if there's logical fault or not?